### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -11,6 +11,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/7](https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/super-linter.yml` at the workflow root so it applies to all jobs (including `run-lint`) unless overridden.  
For this linting workflow, the least-privilege baseline is:

- `contents: read`

This preserves current functionality (checkout + linting) while ensuring token scope is explicitly restricted and documented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
