### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/6](https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/6)

Add an explicit `permissions` block to `.github/workflows/makefile.yml` so the workflow does not rely on mutable repository/organization defaults.  
Best single fix without changing functionality: add a top-level workflow permission block with `contents: read`, which is sufficient for `actions/checkout` and the shown build/test commands.

Change location:
- File: `.github/workflows/makefile.yml`
- Insert immediately after the `on:` trigger block (before `jobs:`), or alternatively at job-level under `build:`.  
Preferred here: workflow-level, since there is only one job and this keeps policy explicit and centralized.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
