### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/8](https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/8)

Add an explicit `permissions` block in `.github/workflows/c-cpp.yml` at the workflow root (recommended here since there is only one job and all current jobs should share the same minimal scope). Set:

- `contents: read`

This preserves existing functionality (checkout/build/setup) while ensuring `GITHUB_TOKEN` is not implicitly granted broader permissions. No new imports, methods, or dependencies are needed—only YAML configuration in the existing workflow file near the top-level keys (`name`, `on`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
