### PR TITLE
Potential fix for code scanning alert no. 9: Potentially unsafe use of strcat

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -7,8 +7,8 @@
 
 static int sysctl_write(const char *node, const char *value) {
     char path[128];
-    strcpy(path, PROC_KERNEL);
-    strcat(path, node);
+    int n = snprintf(path, sizeof(path), "%s%s", PROC_KERNEL, node);
+    if (n < 0 || (size_t)n >= sizeof(path)) return -1;
     
     int fd = open(path, O_WRONLY);
     if (fd < 0) return -1;


### PR DESCRIPTION
Potential fix for [https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/9](https://github.com/X3D-Toggle/x3d-toggle-main/security/code-scanning/9)

Use bounded formatting to construct `path` in one step and reject truncation/overflow.

Best fix in this file: replace `strcpy` + `strcat` with `snprintf(path, sizeof(path), "%s%s", PROC_KERNEL, node)` and validate the return value. If the result is negative or `>= sizeof(path)`, return `-1` before attempting `open`. This preserves behavior for valid inputs, removes unsafe concatenation, and keeps the function contract simple.

Change region: `src/scheduler.c`, inside `sysctl_write` (lines 9–12 in the snippet).

No new headers/imports are required in the shown snippet (project’s `libc.h` likely already provides needed declarations).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
